### PR TITLE
Include the missing file to the build context #4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !mini_node
 !poetry.lock
 !pyproject.toml
+!uvicorn-log-config.yaml


### PR DESCRIPTION
This resolves the Docker build failure due to missing file in the Docker build context.